### PR TITLE
Remove double `pages` field in BibTeX

### DIFF
--- a/src/components/publications/publication.ts
+++ b/src/components/publications/publication.ts
@@ -131,9 +131,5 @@ export const toBibtex = (pub: IPublication): string => {
     bibtex = `${bibtex},\n  note = {${pub.note}}`
   }
 
-  if (pub.pages) {
-    bibtex = `${bibtex},\n  pages = {${pub.pages}}`
-  }
-
   return `${bibtex}\n}`;
 }


### PR DESCRIPTION
We were getting the pages field twice in the generated BibTeX:
```bibtex
@inproceedings {
  title = {Making a robot stop a penalty - Using Q Learning and Transfer Learning},
  author = {Ruben van Heusden},
  year = {2018},
  date = {2018-06-02},
  tags = {BSc, RL, Keeper},
  pages = {89-90},
  booktitle = {Proceedings of the 30th Belgian-Netherlands Conference on Artificial Intelligence (BNAIC 2018)},
  pages = {89-90}
}
```
instead of the intended:
```bibtex
@inproceedings {
  title = {Making a robot stop a penalty - Using Q Learning and Transfer Learning},
  author = {Ruben van Heusden},
  year = {2018},
  date = {2018-06-02},
  tags = {BSc, RL, Keeper},
  pages = {89-90},
  booktitle = {Proceedings of the 30th Belgian-Netherlands Conference on Artificial Intelligence (BNAIC 2018)},
}
```